### PR TITLE
Run pg_dump inside the state container, not on the host.

### DIFF
--- a/lib/stellar_core_commander/docker_process.rb
+++ b/lib/stellar_core_commander/docker_process.rb
@@ -65,7 +65,7 @@ module StellarCoreCommander
     Contract None => Any
     def dump_database
       Dir.chdir(working_dir) do
-        `PGPASSFILE=./.pgpass pg_dump -U #{database_user} -h #{docker_host} -p #{postgres_port} --clean --no-owner #{database_name}`
+        `docker exec #{state_container_name} pg_dump -U #{database_user} --clean --no-owner #{database_name}`
       end
     end
 


### PR DESCRIPTION
This just avoids version mismatches between pg_dump inside and outside the container. As a bonus, you don't need pg_dump outside the container at all anymore :smile: