### PR TITLE
WIP: multi-node recipes

### DIFF
--- a/bin/scc
+++ b/bin/scc
@@ -6,10 +6,8 @@ require 'slop'
 def run
   $opts = Slop.parse do
     banner 'Usage: scc -r RECIPE'
-    
-    on 'stellar-core-bin', 'a path to a stellar-core executable (defaults to `which stellar-core`)', argument: true
 
-    on 'docker-mode', 'mode to run the docker containers in', argument: true, default: 'standalone'
+    on 'stellar-core-bin', 'a path to a stellar-core executable (defaults to `which stellar-core`)', argument: true
 
     on 'r', 'recipe', 'a recipe file', argument: true #, required: true
     on 'p', 'process', 'method for running stellar-core', argument: true, default: 'local'
@@ -18,25 +16,23 @@ def run
   recipe    = load_recipe
   commander = make_commander
 
-  opts = {
-      stellar_core_bin: $opts[:"stellar-core-bin"],
-      docker_mode: $opts[:"docker-mode"]
-  }
-  process   = commander.make_process($opts[:process], opts)
-
   #run recipe
-  transactor = StellarCoreCommander::Transactor.new(process)
-  process.run
-  process.wait_for_ready
+  transactor = StellarCoreCommander::Transactor.new(commander)
+
+
   transactor.run_recipe recipe
   transactor.close_ledger
 
-  output_results(process)
+  output_results(transactor.get_process(:process))
 end
 
 
 def make_commander
-  StellarCoreCommander::Commander.new.tap do |c|
+  opts = {
+    stellar_core_bin: $opts[:"stellar-core-bin"],
+  }
+
+  StellarCoreCommander::Commander.new($opts[:"process"], opts).tap do |c|
     c.cleanup_at_exit!
   end
 end
@@ -62,5 +58,3 @@ def output_results(process)
 end
 
 run
-
- 


### PR DESCRIPTION

At its simplest:

```ruby

# launch a stellar-core process, bound to the name :default.  A recipe must now
# declare at least one process in a recipe.  
process :default

# ... regular recipe steps here.  By default, the first process declared will
# be the target of process-specific recipe steps

```

Let's look at multiple processes:

```ruby

# define a core tier of stellar-core validators, each dependent upon the other 2
# specifying a quorum_set: will make the process startup in non-manual-close mode,
# and calling close_ledger in a recipe that starts a non-manual-close process
# will raise an error
process :core_1, quorum_set: [:core_1, :core_2, :core_3], quorum_threshold: 2
process :core_2, quorum_set: [:core_1, :core_2, :core_3], quorum_threshold: 2
process :core_3, quorum_set: [:core_1, :core_2, :core_3], quorum_threshold: 2

# by default, transactions will get played against :core_1, since it was declared first
create_account :scott, :master
create_account :mat, :master, wait: true # wait: true specifies block recipe processing until this transaction has been successfully validated

wait_for_account :scott # synonymous to specifying wait: true

# the "on" directive targets transactions declared within the directive to the 
# process for the given name
on :core_2 do
  payment :mat, :scott, [:native, 50] 
end

on :core_3 do
  payment :scott, :mat, [:native, 50] 
end
```