### PR TITLE
Re-enable manual ledger closing in recipes through `use_manual_close` directive

### DIFF
--- a/examples/trade.rb
+++ b/examples/trade.rb
@@ -1,3 +1,5 @@
+use_manual_close #use_manual_close causes scc to run a process with MANUAL_CLOSE=true
+
 account :usd_gateway
 account :eur_gateway
 account :scott

--- a/lib/stellar_core_commander/commander.rb
+++ b/lib/stellar_core_commander/commander.rb
@@ -25,10 +25,14 @@ module StellarCoreCommander
     def make_process(transactor, name, quorum, thresh, manual_close=false)
       tmpdir = Dir.mktmpdir("scc")
 
-      identity      = Stellar::KeyPair.random
-      base_port     = 39132 + @processes.map(&:required_ports).sum
-
       process_options = @process_options.merge({
+        transactor:   transactor,
+        working_dir:  tmpdir,
+        name:         name,
+        base_port:    39132 + @processes.map(&:required_ports).sum,
+        identity:     Stellar::KeyPair.random,
+        quorum:       quorum,
+        threshold:    thresh,
         manual_close: manual_close
       })
 
@@ -41,8 +45,7 @@ module StellarCoreCommander
                           raise "Unknown process type: #{@process_type}"
                       end
 
-      process_class.new(transactor, tmpdir, name, base_port,
-                        identity, quorum, thresh, process_options).tap do |p|
+      process_class.new(process_options).tap do |p|
         @processes << p
       end
     end

--- a/lib/stellar_core_commander/docker_process.rb
+++ b/lib/stellar_core_commander/docker_process.rb
@@ -151,6 +151,8 @@ module StellarCoreCommander
         main_PEER_SEED=#{identity.seed}
         main_VALIDATION_SEED=#{identity.seed}
 
+        #{"MANUAL_CLOSE=true" if manual_close?}
+
         QUORUM_THRESHOLD=#{threshold}
 
         PREFERRED_PEERS=#{peers}

--- a/lib/stellar_core_commander/local_process.rb
+++ b/lib/stellar_core_commander/local_process.rb
@@ -155,6 +155,8 @@ module StellarCoreCommander
         DATABASE="#{dsn}"
         PREFERRED_PEERS=#{peers}
 
+        #{"MANUAL_CLOSE=true" if manual_close?}
+
         [QUORUM_SET]
         THRESHOLD=#{threshold}
         VALIDATORS=#{quorum}

--- a/lib/stellar_core_commander/local_process.rb
+++ b/lib/stellar_core_commander/local_process.rb
@@ -6,21 +6,10 @@ module StellarCoreCommander
     attr_reader :pid
     attr_reader :wait
 
-    def initialize(transactor, working_dir, name, base_port, identity, quorum, thresh, opts)
-      stellar_core_bin = opts[:stellar_core_bin]
-      if stellar_core_bin.blank?
-        search = `which stellar-core`.strip
-
-        if $?.success?
-          stellar_core_bin = search
-        else
-          $stderr.puts "Could not find a `stellar-core` binary, please use --stellar-core-bin to specify"
-          exit 1
-        end
-      end
-
-      FileUtils.cp(stellar_core_bin, "#{working_dir}/stellar-core")
+    def initialize(params)
       super
+      @stellar_core_bin = params[:stellar_core_bin]
+      setup_working_dir
     end
 
     Contract None => Any
@@ -166,6 +155,21 @@ module StellarCoreCommander
         put="cp {0} history/main/{1}"
         mkdir="mkdir -p history/main/{0}"
       EOS
+    end
+
+    def setup_working_dir
+      if @stellar_core_bin.blank?
+        search = `which stellar-core`.strip
+
+        if $?.success?
+          @stellar_core_bin = search
+        else
+          $stderr.puts "Could not find a `stellar-core` binary, please use --stellar-core-bin to specify"
+          exit 1
+        end
+      end
+
+      FileUtils.cp(@stellar_core_bin, "#{working_dir}/stellar-core")
     end
 
   end

--- a/lib/stellar_core_commander/process.rb
+++ b/lib/stellar_core_commander/process.rb
@@ -12,17 +12,30 @@ module StellarCoreCommander
     attr_accessor :unverified
     attr_reader :threshold
 
-    def initialize(transactor, working_dir, name, base_port,
-                   identity, quorum, thresh, opts)
-      @transactor   = transactor
-      @working_dir  = working_dir
-      @name         = name
-      @base_port    = base_port
-      @identity     = identity
-      @quorum       = quorum
-      @threshold    = thresh
+    Contract({
+      transactor:   Transactor,
+      working_dir:  String,
+      name:         Symbol,
+      base_port:    Num,
+      identity:     Stellar::KeyPair,
+      quorum:       ArrayOf[Symbol],
+      threshold:    Num,
+      manual_close: Or[Bool, nil],
+    } => Any)
+    def initialize(params)
+      #config
+      @transactor   = params[:transactor]
+      @working_dir  = params[:working_dir]
+      @name         = params[:name]
+      @base_port    = params[:base_port]
+      @identity     = params[:identity]
+      @quorum       = params[:quorum]
+      @threshold    = params[:threshold]
+      @manual_close = params[:manual_close] || false
+
+      # state
       @unverified   = []
-      @manual_close = opts[:manual_close] || false
+
 
       if not @quorum.include? @name
         @quorum << @name

--- a/lib/stellar_core_commander/process.rb
+++ b/lib/stellar_core_commander/process.rb
@@ -176,9 +176,10 @@ module StellarCoreCommander
       database[:ledgerheaders].max(:ledgerseq)
     end
 
-    Contract String => String
+    Contract String => Maybe[String]
     def transaction_result(hex_hash)
       row = database[:txhistory].where(txid:hex_hash).first
+      return if row.blank?
       row[:txresult]
     end
 

--- a/lib/stellar_core_commander/process.rb
+++ b/lib/stellar_core_commander/process.rb
@@ -14,14 +14,15 @@ module StellarCoreCommander
 
     def initialize(transactor, working_dir, name, base_port,
                    identity, quorum, thresh, opts)
-      @transactor  = transactor
-      @working_dir = working_dir
-      @name        = name
-      @base_port   = base_port
-      @identity    = identity
-      @quorum      = quorum
-      @threshold   = thresh
-      @unverified  = []
+      @transactor   = transactor
+      @working_dir  = working_dir
+      @name         = name
+      @base_port    = base_port
+      @identity     = identity
+      @quorum       = quorum
+      @threshold    = thresh
+      @unverified   = []
+      @manual_close = opts[:manual_close] || false
 
       if not @quorum.include? @name
         @quorum << @name
@@ -82,11 +83,19 @@ module StellarCoreCommander
     end
 
     Contract None => Bool
+    def manual_close?
+      @manual_close
+    end
+
+    Contract None => Bool
     def close_ledger
       prev_ledger = latest_ledger
       next_ledger = prev_ledger + 1
 
       Timeout.timeout(close_timeout) do
+
+        server.get("manualclose") if manual_close?
+
         loop do
           current_ledger = latest_ledger
 


### PR DESCRIPTION
In addition to re-enabling manual ledger closing, this PR refactors the `Process` constructor to take a single argument instead of the growing list of positional args.