### PR TITLE
Allow for passing an atlas flag

### DIFF
--- a/bin/scc
+++ b/bin/scc
@@ -29,6 +29,14 @@ def run
       'docker image to use for state',
       argument: true,
       default: 'stellar/stellar-core-state'
+    on 'atlas',
+      'atlas endpoint for publishing metrics',
+      argument: true,
+      default: nil
+    on 'atlas-interval',
+       'internal on which to publish metrics (in seconds)',
+       argument: true,
+       default: 1
   end
 
   recipe    = load_recipe
@@ -55,7 +63,9 @@ def make_commander
   opts = {
     stellar_core_bin: $opts[:"stellar-core-bin"],
     docker_core_image: $opts[:"docker-core-image"],
-    docker_state_image: $opts[:"docker-state-image"]
+    docker_state_image: $opts[:"docker-state-image"],
+    atlas: $opts[:"atlas"],
+    atlas_interval: $opts[:"atlas-interval"].to_i
   }
 
   StellarCoreCommander::Commander.new($opts[:"process"], opts).tap do |c|

--- a/bin/scc
+++ b/bin/scc
@@ -30,11 +30,11 @@ def run
       argument: true,
       default: 'stellar/stellar-core-state'
     on 'atlas',
-      'atlas endpoint for publishing metrics',
+      'atlas endpoint for publishing metrics (e.g., http://192.168.59.103:7101/api/v1/publish)',
       argument: true,
       default: nil
     on 'atlas-interval',
-       'internal on which to publish metrics (in seconds)',
+       'number of seconds to wait between publishing metric payloads',
        argument: true,
        default: 1
   end

--- a/lib/stellar_core_commander/docker_process.rb
+++ b/lib/stellar_core_commander/docker_process.rb
@@ -185,7 +185,7 @@ module StellarCoreCommander
         POSTGRES_PASSWORD=#{database_password}
 
         ENVIRONMENT=scc
-        CLUSTER_NAME=#{File.basename($opts[:recipe], '.rb')}
+        CLUSTER_NAME=#{recipe_name}
         HOSTNAME=#{idname}
 
         main_POSTGRES_PORT=#{postgres_port}
@@ -213,6 +213,12 @@ module StellarCoreCommander
         HISTORY_PUT=cp {0} history/%s/{1}
         HISTORY_MKDIR=mkdir -p history/%s/{0}
       EOS
+    end
+
+    def recipe_name
+      File.basename($opts[:recipe], '.rb')
+    rescue TypeError
+      'recipe_name_not_found'
     end
 
     def docker_port

--- a/lib/stellar_core_commander/docker_process.rb
+++ b/lib/stellar_core_commander/docker_process.rb
@@ -185,7 +185,8 @@ module StellarCoreCommander
         POSTGRES_PASSWORD=#{database_password}
 
         ENVIRONMENT=scc
-        CLUSTER_NAME=#{idname}
+        CLUSTER_NAME=#{File.basename($opts[:recipe], '.rb')}
+        HOSTNAME=#{idname}
 
         main_POSTGRES_PORT=#{postgres_port}
         main_PEER_PORT=#{peer_port}

--- a/lib/stellar_core_commander/local_process.rb
+++ b/lib/stellar_core_commander/local_process.rb
@@ -7,9 +7,12 @@ module StellarCoreCommander
     attr_reader :wait
 
     def initialize(params)
+      raise "`host` param is unsupported on LocalProcess, please use `-p docker` for this recipe." if params[:host]
+      $stderr.puts "Warning: Ignoring `atlas` param since LocalProcess doesn't support this." if params[:atlas]
+
       super
       @stellar_core_bin = params[:stellar_core_bin]
-      raise "`host` param is unsupported on LocalProcess, please use `-p docker` for this recipe." if params[:host]
+
       setup_working_dir
     end
 

--- a/lib/stellar_core_commander/process.rb
+++ b/lib/stellar_core_commander/process.rb
@@ -12,35 +12,40 @@ module StellarCoreCommander
     attr_accessor :unverified
     attr_reader :threshold
     attr_reader :host
+    attr_reader :atlas
+    attr_reader :atlas_interval
 
     DEFAULT_HOST = '127.0.0.1'
 
     Contract({
-      transactor:   Transactor,
-      working_dir:  String,
-      name:         Symbol,
-      base_port:    Num,
-      identity:     Stellar::KeyPair,
-      quorum:       ArrayOf[Symbol],
-      threshold:    Num,
-      manual_close: Or[Bool, nil],
-      host:         Or[String, nil]
+      transactor:     Transactor,
+      working_dir:    String,
+      name:           Symbol,
+      base_port:      Num,
+      identity:       Stellar::KeyPair,
+      quorum:         ArrayOf[Symbol],
+      threshold:      Num,
+      manual_close:   Or[Bool, nil],
+      host:           Or[String, nil],
+      atlas:          Or[String, nil],
+      atlas_interval: Num
     } => Any)
     def initialize(params)
       #config
-      @transactor   = params[:transactor]
-      @working_dir  = params[:working_dir]
-      @name         = params[:name]
-      @base_port    = params[:base_port]
-      @identity     = params[:identity]
-      @quorum       = params[:quorum]
-      @threshold    = params[:threshold]
-      @manual_close = params[:manual_close] || false
-      @host         = params[:host]
+      @transactor     = params[:transactor]
+      @working_dir    = params[:working_dir]
+      @name           = params[:name]
+      @base_port      = params[:base_port]
+      @identity       = params[:identity]
+      @quorum         = params[:quorum]
+      @threshold      = params[:threshold]
+      @manual_close   = params[:manual_close] || false
+      @host           = params[:host]
+      @atlas          = params[:atlas]
+      @atlas_interval = params[:atlas_interval]
 
       # state
       @unverified   = []
-
 
       if not @quorum.include? @name
         @quorum << @name


### PR DESCRIPTION
When present, this will launch an additional stellar/heka container for each node in the recipe. By default this expects the metric interval to be 1s so running at atlas container like so is recommended:

```console
$ docker run --name atlas -p 7101:7101 \
    -d stellar/atlas \
    /run /etc/atlas/atlas.1s.conf
```

Then pass an appropriate atlas argument:

```console
$ scc -r examples/multi_host_simple_payment.rb \
    --atlas http://DOCKER_HOST_IP:7101/api/v1/publish
```