### PR TITLE
Latest containers will use /start instead of /run

### DIFF
--- a/lib/stellar_core_commander/docker_process.rb
+++ b/lib/stellar_core_commander/docker_process.rb
@@ -237,7 +237,7 @@ module StellarCoreCommander
                ) + aws_credentials_volume + shared_history_volume + %W(
                            --env-file stellar-core.env
                            -d #{@docker_core_image}
-                           /run #{@name} fresh forcescp
+                           /start #{@name} fresh forcescp
                ))
       raise "Could not create stellar-core container" unless $?.success?
     end


### PR DESCRIPTION
See https://github.com/stellar/docker-stellar-core/pull/6 for image change.