### PR TITLE
Prepare docker hosts before starting test

### DIFF
--- a/lib/stellar_core_commander/commander.rb
+++ b/lib/stellar_core_commander/commander.rb
@@ -63,7 +63,13 @@ module StellarCoreCommander
 
     Contract None => ArrayOf[Process]
     def start_all_processes
-      @processes.each do |p|
+      stopped = @processes.select(&:stopped?)
+
+      stopped.each do |p|
+        p.prepare
+      end
+
+      stopped.each do |p|
         if not p.running?
           $stderr.puts "running #{p.idname} (dir:#{p.working_dir})"
           p.run

--- a/lib/stellar_core_commander/docker_process.rb
+++ b/lib/stellar_core_commander/docker_process.rb
@@ -180,7 +180,7 @@ module StellarCoreCommander
 
     Contract None => ArrayOf[String]
     def aws_credentials_volume
-      if use_s3 and (not host)
+      if use_s3 and File.exists?("#{ENV['HOME']}/.aws")
         ["-v", "#{ENV['HOME']}/.aws:/root/.aws:ro"]
       else
         []

--- a/lib/stellar_core_commander/process.rb
+++ b/lib/stellar_core_commander/process.rb
@@ -377,5 +377,14 @@ module StellarCoreCommander
       end
     end
 
+    Contract None => Bool
+    def stopped?
+      !running?
+    end
+
+    Contract None => Any
+    def prepare
+      nil
+    end
   end
 end


### PR DESCRIPTION
This allows docker pull to happen before anything starts running and avoid
timing differences when the image is fresh vs already downloaded to the
docker host.