### PR TITLE
Fixes (forcescp: true) from be interpreted as false:

### DIFF
--- a/lib/stellar_core_commander/process.rb
+++ b/lib/stellar_core_commander/process.rb
@@ -57,9 +57,9 @@ module StellarCoreCommander
       @quorum         = params[:quorum]
       @threshold      = params[:threshold]
       @manual_close   = params[:manual_close] || false
-      @await_sync     = params[:await_sync].nil? && true
+      @await_sync     = params.fetch(:await_sync, true)
       @accelerate_time = params[:accelerate_time] || false
-      @forcescp       = params[:forcescp].nil? && true
+      @forcescp       = params.fetch(:forcescp, true)
       @host           = params[:host]
       @atlas          = params[:atlas]
       @atlas_interval = params[:atlas_interval]


### PR DESCRIPTION
`(true.nil? && true) == false`, and thus specifying `forcescp: true` actually has the reverse effect.

This commit changes to using Hash#fetch to implement default values.