### PR TITLE
Crash handling for scc

### DIFF
--- a/lib/stellar_core_commander/docker_process.rb
+++ b/lib/stellar_core_commander/docker_process.rb
@@ -219,6 +219,10 @@ module StellarCoreCommander
       docker %W(pull stellar/heka)
     end
 
+    def crash
+      docker %W(exec #{container_name} pkill -ABRT stellar-core)
+    end
+
     private
     def launch_stellar_core
       $stderr.puts "launching stellar-core container #{container_name}"

--- a/lib/stellar_core_commander/local_process.rb
+++ b/lib/stellar_core_commander/local_process.rb
@@ -111,6 +111,10 @@ module StellarCoreCommander
       "postgres://localhost/#{idname}"
     end
 
+    def crash
+      `kill -ABRT #{@pid}`
+    end
+
     private
     def launch_stellar_core
       Dir.chdir @working_dir do

--- a/lib/stellar_core_commander/transactor.rb
+++ b/lib/stellar_core_commander/transactor.rb
@@ -256,6 +256,10 @@ module StellarCoreCommander
       @process.catchup ledger, mode
     end
 
+    Contract None => Any
+    def crash
+      @process.crash
+    end
 
     Contract Symbol => Stellar::KeyPair
     def get_account(name)


### PR DESCRIPTION
Requires https://github.com/stellar/docker-stellar-core/pull/10 for backtrace handling

Requires something like https://github.com/ohjames/lovely_touching in the stellar/stellar-core image to handle ABRT when running on docker.

Feedback welcome on whether or not we should incorporate that into our published docker image.