### PR TITLE
Add catchup-to-testnet code and test

### DIFF
--- a/examples/history_testnet_catchup.rb
+++ b/examples/history_testnet_catchup.rb
@@ -1,0 +1,5 @@
+process :node1, [:testnet1, :testnet2, :testnet3], 2, forcescp: false
+on :node1 do
+  raise "node1 synced but failed to catch up" if ledger_num < 5
+  $stderr.puts "caught up on node1: ledger #{ledger_num}"
+end

--- a/lib/stellar_core_commander/process.rb
+++ b/lib/stellar_core_commander/process.rb
@@ -28,6 +28,27 @@ module StellarCoreCommander
 
     DEFAULT_HOST = '127.0.0.1'
 
+    SPECIAL_PEERS = {
+      :testnet1 => {
+        :dns => "core-testnet1.stellar.org",
+        :key => "gTDZhQ14WuP8rQ9SrkS1EhWNhZyybv97cHNsGRADKQtBoJpTTk",
+        :name => "core-testnet-001",
+        :get => "curl -sf https://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-testnet/%s/{0} -o {1}"
+      },
+      :testnet2 => {
+        :dns => "core-testnet2.stellar.org",
+        :key => "gsjjWTsQP5C2HpcetiLz4LDa9VECGvZMTyhPUDWi57ZKafV5sA4",
+        :name => "core-testnet-002",
+        :get => "curl -sf https://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-testnet/%s/{0} -o {1}"
+      },
+      :testnet3 => {
+        :dns => "core-testnet3.stellar.org",
+        :key => "gSCB2HML88CvMwt2iryJGdS61gDr2nhMeYFVWF2B4m6w5js73T",
+        :name => "core-testnet-003",
+        :get => "curl -sf https://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-testnet/%s/{0} -o {1}"
+      }
+    }
+
     Contract({
       transactor:        Transactor,
       working_dir:       String,
@@ -86,21 +107,36 @@ module StellarCoreCommander
 
     Contract None => ArrayOf[String]
     def quorum
-      @quorum.map do |q|
-        @transactor.get_process(q).identity.address
+      specials = @quorum.select {|q| SPECIAL_PEERS.has_key? q}
+      if specials.empty?
+        @quorum.map do |q|
+          @transactor.get_process(q).identity.address
+        end
+      else
+        specials.map {|q| SPECIAL_PEERS[q][:key]}
       end
     end
 
     Contract None => ArrayOf[String]
     def peer_names
-      @quorum.map {|x| x.to_s}
+      specials = @quorum.select {|q| SPECIAL_PEERS.has_key? q}
+      if specials.empty?
+        @quorum.map {|q| q.to_s}
+      else
+        specials.map {|q| SPECIAL_PEERS[q][:name]}
+      end
     end
 
     Contract None => ArrayOf[String]
     def peer_connections
-      @quorum.map do |q|
-        p = @transactor.get_process(q)
-        "#{p.hostname}:#{p.peer_port}"
+      specials = @quorum.select {|q| SPECIAL_PEERS.has_key? q}
+      if specials.empty?
+        @quorum.map do |q|
+          p = @transactor.get_process(q)
+          "#{p.hostname}:#{p.peer_port}"
+        end
+      else
+        specials.map {|q| SPECIAL_PEERS[q][:dns]}
       end
     end
 


### PR DESCRIPTION
This hard-wires `:testnet1`, `:testnet2` and `:testnet3` as magic node names that redirect scc to talk to the testnet. Adds a test that uses it. Only half-tested since testnet is running non-master code presently.