### PR TITLE
Fix thresholds helper, extract `set_master_signer_weight`

### DIFF
--- a/examples/set_options.rb
+++ b/examples/set_options.rb
@@ -1,0 +1,23 @@
+use_manual_close
+
+account :scott
+account :bartek
+create_account :scott
+create_account :bartek
+
+close_ledger
+
+kp = Stellar::KeyPair.random
+
+set_inflation_dest :scott, :bartek
+set_flags :scott, [:auth_required_flag]
+set_master_signer_weight :scott, 2
+set_thresholds :scott, low: 0, medium: 2, high: 2
+set_thresholds :scott, high: 1
+set_home_domain :scott, "nullstyle.com"
+add_signer :scott, kp, 1
+
+close_ledger
+
+clear_flags :scott, [:auth_required_flag]
+remove_signer :scott, kp

--- a/lib/stellar_core_commander/transactor.rb
+++ b/lib/stellar_core_commander/transactor.rb
@@ -161,6 +161,14 @@ module StellarCoreCommander
     end
 
     #
+    # @see StellarCoreCommander::OperationBuilder#set_master_signer_weight
+    def set_master_signer_weight(*args)
+      require_process_running
+      envelope = @operation_builder.set_master_signer_weight(*args)
+      submit_transaction envelope
+    end
+
+    #
     # @see StellarCoreCommander::OperationBuilder#remove_signer
     def remove_signer(*args)
       require_process_running

--- a/stellar_core_commander.gemspec
+++ b/stellar_core_commander.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "stellar-base", ">= 0.0.19"
+  spec.add_dependency "stellar-base", ">= 0.0.20"
   spec.add_dependency "slop", "~> 3.6.0"
   spec.add_dependency "faraday", "~> 0.9.1"
   spec.add_dependency "faraday_middleware", "~> 0.9.1"


### PR DESCRIPTION
This PR modifies the `set_options` recipe step to be compatible with the latest form of the SetOptionsOp xdr struct.  In addition, it extracts a recipe step called `set_master_signer_weight` for more ease of use.  Finally, we add an example recipe that exercises. all the set_options related helpers.