### PR TITLE
Avoid mutating quorum list, which may be reused between processes.

### DIFF
--- a/lib/stellar_core_commander/process.rb
+++ b/lib/stellar_core_commander/process.rb
@@ -101,7 +101,7 @@ module StellarCoreCommander
       @unverified   = []
 
       if not @quorum.include? @name
-        @quorum << @name
+        @quorum = @quorum + [@name]
       end
 
       @server = Faraday.new(url: "http://#{hostname}:#{http_port}") do |conn|


### PR DESCRIPTION
Turns out when we use a single quorum-list variable in a recipe and thread it through multiple processes, it accumulates a new member for each place it's used. This causes topologies with core/listener splits to have listeners that treat their neighbours as quorum-members (and history members), and the complex-topology test fails.

Not mutating the quorum-list fixes it.