### PR TITLE
Add peers: and validate: keywords.

### DIFF
--- a/lib/stellar_core_commander/docker_process.rb
+++ b/lib/stellar_core_commander/docker_process.rb
@@ -240,7 +240,7 @@ module StellarCoreCommander
 
     Contract None => String
     def history_put_commands
-      if has_special_nodes?
+      if has_special_peers?
         ""
       else
         if use_s3
@@ -297,7 +297,7 @@ module StellarCoreCommander
         #{@name}_PEER_PORT=#{peer_port}
         #{@name}_HTTP_PORT=#{http_port}
         #{@name}_PEER_SEED=#{identity.seed}
-        #{@name}_VALIDATION_SEED=#{identity.seed}
+        #{"#{@name}_VALIDATION_SEED=#{identity.seed}" if @validate}
 
         #{"MANUAL_CLOSE=true" if manual_close?}
 

--- a/lib/stellar_core_commander/local_process.rb
+++ b/lib/stellar_core_commander/local_process.rb
@@ -158,7 +158,7 @@ module StellarCoreCommander
         HTTP_PORT=#{http_port}
         PUBLIC_HTTP_PORT=false
         PEER_SEED="#{@identity.seed}"
-        VALIDATION_SEED="#{@identity.seed}"
+        #{"VALIDATION_SEED=#{identity.seed}" if @validate}
 
         ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING=true
         #{"ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING=true" if @accelerate_time}


### PR DESCRIPTION
Two new keywords for processes. `peers:` lets us specify the peers to talk to (for the purposes of history and overlay) independent of the quorum, though it defaults to quorum if not provided. `validate:` lets us disable validation-seeds for a given process, making read-replicas.