### PR TITLE
Debug improvements

### DIFF
--- a/bin/scc
+++ b/bin/scc
@@ -67,8 +67,6 @@ def run
   transactor.run_recipe recipe
   transactor.close_ledger
 
-  output_results(commander.get_root_process transactor)
-
   if $opts[:wait]
     $stderr.puts "Waiting for INT signal..."
     Signal.trap("INT"){ exit }
@@ -117,10 +115,6 @@ def load_recipe
   end
 
   recipe
-end
-
-def output_results(process)
-  $stdout.puts process.dump_database
 end
 
 run

--- a/lib/stellar_core_commander/commander.rb
+++ b/lib/stellar_core_commander/commander.rb
@@ -84,7 +84,12 @@ module StellarCoreCommander
         begin
           p.wait_for_ready unless p.synced?
         rescue Timeout::Error
-          raise "process #{p.name} lost sync"
+          @processes.each do |p2|
+            p2.dump_scp_state
+            p2.dump_info
+            p2.dump_metrics
+            raise "process #{p.name} lost sync"
+          end
         end
       end
     end

--- a/lib/stellar_core_commander/docker_process.rb
+++ b/lib/stellar_core_commander/docker_process.rb
@@ -309,6 +309,8 @@ module StellarCoreCommander
 
         METRICS_INTERVAL=#{atlas_interval}
 
+        #{"COMMANDS=[\"ll?level=debug\"]" if @debug}
+
         QUORUM_THRESHOLD=#{threshold}
 
         PREFERRED_PEERS=#{peer_connections}

--- a/lib/stellar_core_commander/docker_process.rb
+++ b/lib/stellar_core_commander/docker_process.rb
@@ -123,10 +123,11 @@ module StellarCoreCommander
 
     Contract None => Any
     def dump_database
-      Dir.chdir(working_dir) do
-        host_args = "-H tcp://#{docker_host}:#{docker_port}" if host
-        `docker #{host_args} exec #{state_container_name} pg_dump -U #{database_user} --clean --no-owner --no-privileges #{database_name}`
-      end
+      fname = "#{working_dir}/database-#{Time.now.to_i}-#{rand 100000}.sql"
+      $stderr.puts "dumping database to #{fname}"
+      host_args = "-H tcp://#{docker_host}:#{docker_port}" if host
+      sql = `docker #{host_args} exec #{state_container_name} pg_dump -U #{database_user} --clean --no-owner --no-privileges #{database_name}`
+      File.open(fname, 'w') {|f| f.write(sql) }
     end
 
     Contract None => String

--- a/lib/stellar_core_commander/docker_process.rb
+++ b/lib/stellar_core_commander/docker_process.rb
@@ -102,8 +102,11 @@ module StellarCoreCommander
     Contract None => Any
     def cleanup
       database.disconnect
+      dump_database
       dump_logs
       dump_cores
+      dump_scp_state
+      dump_info
       dump_metrics
       shutdown
       shutdown_state_container

--- a/lib/stellar_core_commander/local_process.rb
+++ b/lib/stellar_core_commander/local_process.rb
@@ -168,6 +168,7 @@ module StellarCoreCommander
         PREFERRED_PEERS=#{peer_connections}
 
         #{"MANUAL_CLOSE=true" if manual_close?}
+        #{"COMMANDS=[\"ll?level=debug\"]" if @debug}
 
         [QUORUM_SET]
         THRESHOLD=#{threshold}

--- a/lib/stellar_core_commander/local_process.rb
+++ b/lib/stellar_core_commander/local_process.rb
@@ -105,9 +105,10 @@ module StellarCoreCommander
 
     Contract None => Any
     def dump_database
-      Dir.chdir(@working_dir) do
-        `pg_dump #{database_name} --clean --no-owner --no-privileges`
-      end
+      fname = "#{working_dir}/database-#{Time.now.to_i}-#{rand 100000}.sql"
+      $stderr.puts "dumping database to #{fname}"
+      sql = `pg_dump #{database_name} --clean --no-owner --no-privileges`
+      File.open(fname, 'w') {|f| f.write(sql) }
     end
 
     Contract None => String

--- a/lib/stellar_core_commander/local_process.rb
+++ b/lib/stellar_core_commander/local_process.rb
@@ -98,6 +98,9 @@ module StellarCoreCommander
     Contract None => Any
     def cleanup
       database.disconnect
+      dump_database
+      dump_scp_state
+      dump_info
       dump_metrics
       shutdown
       drop_database unless @keep_database

--- a/lib/stellar_core_commander/process.rb
+++ b/lib/stellar_core_commander/process.rb
@@ -75,6 +75,7 @@ module StellarCoreCommander
       s3_history_region: String,
       database_url:      Maybe[String],
       keep_database:     Maybe[Bool],
+      debug:             Maybe[Bool],
     } => Any)
     def initialize(params)
       #config
@@ -100,6 +101,7 @@ module StellarCoreCommander
       @s3_history_prefix = params[:s3_history_prefix]
       @database_url      = params[:database_url]
       @keep_database     = params[:keep_database]
+      @debug             = params[:debug]
 
       # state
       @unverified   = []

--- a/lib/stellar_core_commander/process.rb
+++ b/lib/stellar_core_commander/process.rb
@@ -333,12 +333,29 @@ module StellarCoreCommander
       0
     end
 
-    Contract None => Any
-    def dump_metrics
-      response = server.get("/metrics")
-      File.open("#{working_dir}/stellar-metrics.json", 'w') {|f| f.write(response.body) }
+    Contract String => Any
+    def dump_server_query(s)
+      fname = "#{working_dir}/#{s}-#{Time.now.to_i}-#{rand 100000}.json"
+      $stderr.puts "dumping server query #{fname}"
+      response = server.get("/#{s}")
+      File.open(fname, 'w') {|f| f.write(response.body) }
     rescue
       nil
+    end
+
+    Contract None => Any
+    def dump_metrics
+      dump_server_query("metrics")
+    end
+
+    Contract None => Any
+    def dump_info
+      dump_server_query("info")
+    end
+
+    Contract None => Any
+    def dump_scp_state
+      dump_server_query("scp")
     end
 
     Contract None => Num


### PR DESCRIPTION
This adds a new `debug:` parameter to processes as well as capturing the DB state in a separate SQL file rather than stdout (it gets huge when doing loadgen) and writing the `/scp`, `/metrics` and `/info` queries to regular files in the node output directories.