### PR TITLE
Add support for network-passphrase

### DIFF
--- a/bin/scc
+++ b/bin/scc
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'stellar_core_commander'
+require 'stellar-base'
 require 'slop'
 
 def run
@@ -60,6 +61,10 @@ def run
       'when true, dump to root processes sql database after recipe completion',
       argument: false,
       default: false
+    on 'network-passphrase',
+      'sets the network passphrase to configure on all running processes',
+      argument: true,
+      default: Stellar::Networks::TESTNET
   end
 
   recipe    = load_recipe
@@ -94,7 +99,8 @@ def make_commander
     atlas_interval: $opts[:"atlas-interval"].to_i,
     use_s3: $opts[:"use-s3"],
     s3_history_region: $opts[:"s3-history-region"],
-    s3_history_prefix: $opts[:"s3-history-prefix"]
+    s3_history_prefix: $opts[:"s3-history-prefix"],
+    network_passphrase: $opts[:"network-passphrase"],
   }
 
   destination = $opts[:"destination"]

--- a/lib/stellar_core_commander/commander.rb
+++ b/lib/stellar_core_commander/commander.rb
@@ -9,6 +9,8 @@ module StellarCoreCommander
   class Commander
     include Contracts
 
+    attr_reader :process_options
+
     #
     # Creates a new core commander
     #

--- a/lib/stellar_core_commander/docker_process.rb
+++ b/lib/stellar_core_commander/docker_process.rb
@@ -323,6 +323,8 @@ module StellarCoreCommander
         VALIDATORS=#{quorum}
 
         HISTORY_PEERS=#{peer_names}
+
+        NETWORK_PASSPHRASE="#{network_passphrase}"
       EOS
       ) + history_get_command + history_put_commands
     end

--- a/lib/stellar_core_commander/local_process.rb
+++ b/lib/stellar_core_commander/local_process.rb
@@ -160,6 +160,8 @@ module StellarCoreCommander
         FAILURE_SAFETY=0
         UNSAFE_QUORUM=true
 
+        NETWORK_PASSPHRASE="#{network_passphrase}"
+
         [QUORUM_SET]
         VALIDATORS=#{quorum}
 

--- a/lib/stellar_core_commander/process.rb
+++ b/lib/stellar_core_commander/process.rb
@@ -27,6 +27,7 @@ module StellarCoreCommander
     attr_reader :host
     attr_reader :atlas
     attr_reader :atlas_interval
+    attr_reader :network_passphrase
 
     DEFAULT_HOST = '127.0.0.1'
 
@@ -52,53 +53,55 @@ module StellarCoreCommander
     }
 
     Contract({
-      transactor:        Transactor,
-      working_dir:       String,
-      name:              Symbol,
-      base_port:         Num,
-      identity:          Stellar::KeyPair,
-      quorum:            ArrayOf[Symbol],
-      peers:             Maybe[ArrayOf[Symbol]],
-      manual_close:      Maybe[Bool],
-      await_sync:        Maybe[Bool],
-      accelerate_time:   Maybe[Bool],
-      catchup_complete:  Maybe[Bool],
-      forcescp:          Maybe[Bool],
-      validate:          Maybe[Bool],
-      host:              Maybe[String],
-      atlas:             Maybe[String],
-      atlas_interval:    Num,
-      use_s3:            Bool,
-      s3_history_prefix: String,
-      s3_history_region: String,
-      database_url:      Maybe[String],
-      keep_database:     Maybe[Bool],
-      debug:             Maybe[Bool],
+      transactor:          Transactor,
+      working_dir:         String,
+      name:                Symbol,
+      base_port:           Num,
+      identity:            Stellar::KeyPair,
+      quorum:              ArrayOf[Symbol],
+      peers:               Maybe[ArrayOf[Symbol]],
+      manual_close:        Maybe[Bool],
+      await_sync:          Maybe[Bool],
+      accelerate_time:     Maybe[Bool],
+      catchup_complete:    Maybe[Bool],
+      forcescp:            Maybe[Bool],
+      validate:            Maybe[Bool],
+      host:                Maybe[String],
+      atlas:               Maybe[String],
+      atlas_interval:      Num,
+      use_s3:              Bool,
+      s3_history_prefix:   String,
+      s3_history_region:   String,
+      database_url:        Maybe[String],
+      keep_database:       Maybe[Bool],
+      debug:               Maybe[Bool],
+      network_passphrase:  Maybe[String],
     } => Any)
     def initialize(params)
       #config
-      @transactor        = params[:transactor]
-      @working_dir       = params[:working_dir]
-      @name              = params[:name]
-      @base_port         = params[:base_port]
-      @identity          = params[:identity]
-      @quorum            = params[:quorum]
-      @peers             = params[:peers] || params[:quorum]
-      @manual_close      = params[:manual_close] || false
-      @await_sync        = params.fetch(:await_sync, true)
-      @accelerate_time   = params[:accelerate_time] || false
-      @catchup_complete  = params[:catchup_complete] || false
-      @forcescp          = params.fetch(:forcescp, true)
-      @validate          = params.fetch(:validate, true)
-      @host              = params[:host]
-      @atlas             = params[:atlas]
-      @atlas_interval    = params[:atlas_interval]
-      @use_s3            = params[:use_s3]
-      @s3_history_region = params[:s3_history_region]
-      @s3_history_prefix = params[:s3_history_prefix]
-      @database_url      = params[:database_url]
-      @keep_database     = params[:keep_database]
-      @debug             = params[:debug]
+      @transactor         = params[:transactor]
+      @working_dir        = params[:working_dir]
+      @name               = params[:name]
+      @base_port          = params[:base_port]
+      @identity           = params[:identity]
+      @quorum             = params[:quorum]
+      @peers              = params[:peers] || params[:quorum]
+      @manual_close       = params[:manual_close] || false
+      @await_sync         = params.fetch(:await_sync, true)
+      @accelerate_time    = params[:accelerate_time] || false
+      @catchup_complete   = params[:catchup_complete] || false
+      @forcescp           = params.fetch(:forcescp, true)
+      @validate           = params.fetch(:validate, true)
+      @host               = params[:host]
+      @atlas              = params[:atlas]
+      @atlas_interval     = params[:atlas_interval]
+      @use_s3             = params[:use_s3]
+      @s3_history_region  = params[:s3_history_region]
+      @s3_history_prefix  = params[:s3_history_prefix]
+      @database_url       = params[:database_url]
+      @keep_database      = params[:keep_database]
+      @debug              = params[:debug]
+      @network_passphrase = params[:network_passphrase] || Stellar::Networks::TESTNET
 
       # state
       @unverified   = []

--- a/lib/stellar_core_commander/transactor.rb
+++ b/lib/stellar_core_commander/transactor.rb
@@ -21,7 +21,10 @@ module StellarCoreCommander
       @operation_builder = OperationBuilder.new(self)
       @manual_close      = false
 
-      account :master, Stellar::KeyPair.from_raw_seed("allmylifemyhearthasbeensearching")
+      network_passphrase = @commander.process_options[:network_passphrase]
+      Stellar.on_network network_passphrase do
+        account :master, Stellar::KeyPair.master
+      end
     end
 
     def require_process_running
@@ -49,7 +52,10 @@ module StellarCoreCommander
     #
     def run_recipe(recipe_path)
       recipe_content = IO.read(recipe_path)
-      instance_eval recipe_content, recipe_path, 1
+      network_passphrase = @commander.process_options[:network_passphrase]
+      Stellar.on_network network_passphrase do
+        instance_eval recipe_content, recipe_path, 1
+      end
     rescue => e
       crash_recipe e
     end

--- a/stellar_core_commander.gemspec
+++ b/stellar_core_commander.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "stellar-base", ">= 0.1.1"
+  spec.add_dependency "stellar-base", ">= 0.3.0"
   spec.add_dependency "slop", "~> 3.6.0"
   spec.add_dependency "faraday", "~> 0.9.1"
   spec.add_dependency "faraday_middleware", "~> 0.9.1"


### PR DESCRIPTION
This PR adds minimal support for specifying a passphrase to use for the test networks created by scc.  It allows you to specify a `--network-passphrase` command line argument that will be used for all processes created by scc.

In the future, we may want to add capabilities to have different passphrases on a per-process basis in service of the delivery pipeline's needs, but for now this should be sufficient to get us running again.