### PR TITLE
Misc fixes

### DIFF
--- a/bin/scc
+++ b/bin/scc
@@ -67,14 +67,18 @@ def run
       default: Stellar::Networks::TESTNET
   end
 
+  Stellar::default_network = $opts[:"network-passphrase"]
+
   recipe    = load_recipe
   commander = make_commander
 
   #run recipe
   transactor = StellarCoreCommander::Transactor.new(commander)
 
+  #run the recipe
   transactor.run_recipe recipe
   transactor.close_ledger
+
 
   if $opts[:"dump-root-db"]
     file = commander.get_root_process(transactor).dump_database

--- a/lib/stellar_core_commander/transactor.rb
+++ b/lib/stellar_core_commander/transactor.rb
@@ -21,10 +21,7 @@ module StellarCoreCommander
       @operation_builder = OperationBuilder.new(self)
       @manual_close      = false
 
-      network_passphrase = @commander.process_options[:network_passphrase]
-      Stellar.on_network network_passphrase do
-        account :master, Stellar::KeyPair.master
-      end
+      account :master, Stellar::KeyPair.master
     end
 
     def require_process_running
@@ -52,10 +49,7 @@ module StellarCoreCommander
     #
     def run_recipe(recipe_path)
       recipe_content = IO.read(recipe_path)
-      network_passphrase = @commander.process_options[:network_passphrase]
-      Stellar.on_network network_passphrase do
-        instance_eval recipe_content, recipe_path, 1
-      end
+      instance_eval recipe_content, recipe_path, 1
     rescue => e
       crash_recipe e
     end
@@ -392,9 +386,11 @@ module StellarCoreCommander
     def submit_transaction(envelope, &after_confirmation)
       require_process_running
       b64    = envelope.to_xdr(:base64)
-      @process.submit_transaction b64
 
       # submit to process
+      @process.submit_transaction b64
+
+      # register envelope for validation after ledger is closed
       @process.unverified << [envelope, after_confirmation]
     end
 

--- a/lib/stellar_core_commander/transactor.rb
+++ b/lib/stellar_core_commander/transactor.rb
@@ -177,6 +177,7 @@ module StellarCoreCommander
         rescue MissingTransaction
           $stderr.puts "Failed to validate tx: #{Convert.to_hex envelope.tx.hash}"
           $stderr.puts "could not be found in txhistory table on process #{@process.name}"
+          exit 1
         rescue FailedTransaction
           $stderr.puts "Failed to validate tx: #{Convert.to_hex envelope.tx.hash}"
           $stderr.puts "failed result: #{result.to_xdr(:base64)}"


### PR DESCRIPTION
This PR fixes a couple of bugs:

- A recipe that crashes due to a missing transaction now properly exits with a non-zero status
- The configured network passphrase is now set using `Stellar.default_network=` instead of `Stellar.on_network` to ensure it is used univerally.