### PR TITLE
Misc improvements

### DIFF
--- a/lib/stellar_core_commander/horizon_commander.rb
+++ b/lib/stellar_core_commander/horizon_commander.rb
@@ -44,7 +44,7 @@ module StellarCoreCommander
     def wait
       $stderr.puts "waiting for all open txns"
       @conn.parallel_manager.run
-      
+
       @open.each do |resp|
         unless resp.success?
           require 'pry'; binding.pry
@@ -111,6 +111,12 @@ module StellarCoreCommander
       @open << @conn.post("transactions", tx: b64)
     end
 
+    Contract Symbol => Any
+    def create_via_friendbot(account)
+      account = get_account account
+      @open << @conn.get("friendbot", addr: account.address)
+    end
+
     Contract Exception => Any
     def crash_recipe(e)
       puts
@@ -126,4 +132,3 @@ module StellarCoreCommander
 
   end
 end
-

--- a/lib/stellar_core_commander/operation_builder.rb
+++ b/lib/stellar_core_commander/operation_builder.rb
@@ -44,7 +44,22 @@ module StellarCoreCommander
       @transactor = transactor
     end
 
-    Contract Symbol, Symbol, Amount, Or[{}, {path: ArrayOf[Asset], with:Amount}] => Any
+    Memo = Or[
+      Integer,
+      String,
+      [:id, Integer],
+      [:text, String],
+      [:hash, String],
+      [:return, String],
+    ]
+
+    CommonOptions = {memo: Maybe[Memo]}
+    PaymentOptions = Or[
+      CommonOptions,
+      CommonOptions.merge({path: ArrayOf[Asset], with:Amount}),
+    ]
+
+    Contract Symbol, Symbol, Amount, PaymentOptions => Any
     def payment(from, to, amount, options={})
       from = get_account from
       to   = get_account to
@@ -52,6 +67,7 @@ module StellarCoreCommander
       attrs = {
         account:     from,
         destination: to,
+        memo:        options[:memo],
         sequence:    next_sequence(from),
         amount:      normalize_amount(amount),
       }

--- a/stellar_core_commander.gemspec
+++ b/stellar_core_commander.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "stellar-base", ">= 0.6.1"
+  spec.add_dependency "stellar-base", ">= 0.10.0"
   spec.add_dependency "slop", "~> 3.6.0"
   spec.add_dependency "faraday", "~> 0.9.1"
   spec.add_dependency "faraday_middleware", "~> 0.9.1"


### PR DESCRIPTION
- Adds `create_with_friendbot` recipe step available to "hcc" recipes
- Adds memo support for both "scc" and "hcc" payment calls.
- Bump stellar-base dependency to 0.10.0 (which is needed for memo support)