### PR TITLE
cache sequence_for value between ledger closes

### DIFF
--- a/lib/stellar_core_commander/process.rb
+++ b/lib/stellar_core_commander/process.rb
@@ -140,6 +140,7 @@ module StellarCoreCommander
 
       # state
       @unverified   = []
+      @sequences    = Hash.new {|hash, account| hash[account] = (account_row account)[:seqnum]}
 
       if not @quorum.include? @name
         @quorum = @quorum + [@name]
@@ -301,6 +302,7 @@ module StellarCoreCommander
           end
         end
       end
+      @sequences.clear
       $stderr.puts "#{idname} closed #{latest_ledger}"
 
       true
@@ -497,7 +499,7 @@ module StellarCoreCommander
 
     Contract Stellar::KeyPair => Num
     def sequence_for(account)
-      (account_row account)[:seqnum]
+      @sequences[account]
     end
 
     Contract Stellar::KeyPair => Num


### PR DESCRIPTION
If it happens that process closes ledger without we knowing it - value
of tx_seq will be invalid, as it is a sum of sequence_for and number of
transactions that process does not know are validated. So in that case
some transactions would be counted twice.

Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>