### PR TITLE
removed obsolete DESIRED_MAX_TX_PER_LEDGER out of the config file

### DIFF
--- a/lib/stellar_core_commander/docker_process.rb
+++ b/lib/stellar_core_commander/docker_process.rb
@@ -328,7 +328,6 @@ module StellarCoreCommander
         #{"MANUAL_CLOSE=true" if manual_close?}
 
         ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING=true
-        DESIRED_MAX_TX_PER_LEDGER=10000
         #{"ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING=true" if @accelerate_time}
         #{"CATCHUP_COMPLETE=true" if @catchup_complete}
         #{"CATCHUP_RECENT=" + @catchup_recent.to_s if @catchup_recent}

--- a/lib/stellar_core_commander/local_process.rb
+++ b/lib/stellar_core_commander/local_process.rb
@@ -149,7 +149,6 @@ module StellarCoreCommander
         #{"NODE_IS_VALIDATOR=true" if @validate}
 
         ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING=true
-        DESIRED_MAX_TX_PER_LEDGER=10000
         #{"ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING=true" if @accelerate_time}
         #{"CATCHUP_COMPLETE=true" if @catchup_complete}
         #{"CATCHUP_RECENT=" + @catchup_recent.to_s if @catchup_recent}

--- a/lib/stellar_core_commander/process.rb
+++ b/lib/stellar_core_commander/process.rb
@@ -294,6 +294,11 @@ module StellarCoreCommander
       true
     end
 
+    Contract None => Any
+    def set_max_tx
+      server.get('/upgrades?mode=set&upgradetime=1970-01-01T00:00:00Z&maxtxsize=10000')
+    end
+
     Contract Num, Symbol => Any
     def catchup(ledger, mode)
       server.get("/catchup?ledger=#{ledger}&mode=#{mode}")
@@ -653,6 +658,7 @@ module StellarCoreCommander
       setup
       launch_process
       @launched = true
+      set_max_tx
     end
 
     # Dumps the database of the process to the working directory, returning the path to the file written to


### PR DESCRIPTION
not sure how to test this

this moves changing the limit for max number of tx per ledger from the config file to a command invoked when starting up core
