### PR TITLE
Fixes

### DIFF
--- a/lib/stellar_core_commander/commander.rb
+++ b/lib/stellar_core_commander/commander.rb
@@ -23,7 +23,7 @@ module StellarCoreCommander
       @processes = []
 
       if File.exist? @destination
-        $stderr.puts "scc is not capable of using an existing destination directory.  Please rename or remove #{@destination} amd try again"
+        $stderr.puts "scc is not capable of running with an existing destination directory.  Please rename or remove #{@destination} and try again"
         exit 1
       end
     end

--- a/lib/stellar_core_commander/commander.rb
+++ b/lib/stellar_core_commander/commander.rb
@@ -21,6 +21,11 @@ module StellarCoreCommander
       @destination = destination
       @process_options = process_options
       @processes = []
+
+      if File.exist? @destination
+        $stderr.puts "scc is not capable of using an existing destination directory.  Please rename or remove #{@destination} amd try again"
+        exit 1
+      end
     end
 
     Contract Transactor, Symbol, ArrayOf[Symbol], Hash => Process

--- a/lib/stellar_core_commander/process.rb
+++ b/lib/stellar_core_commander/process.rb
@@ -302,6 +302,11 @@ module StellarCoreCommander
       server.get('/upgrades?mode=set&upgradetime=1970-01-01T00:00:00Z&maxtxsize=10000')
     end
 
+    Contract None => Any
+    def set_protocol_version
+      server.get('/upgrades?mode=set&upgradetime=1970-01-01T00:00:00Z&protocolversion=9')
+    end
+
     Contract Num, Symbol => Any
     def catchup(ledger, mode)
       server.get("/catchup?ledger=#{ledger}&mode=#{mode}")
@@ -694,6 +699,7 @@ module StellarCoreCommander
 
       wait_for_http
       set_max_tx
+      set_protocol_version
     end
 
     # Dumps the database of the process to the working directory, returning the path to the file written to

--- a/stellar_core_commander.gemspec
+++ b/stellar_core_commander.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", "~> 0.9.1"
   spec.add_dependency "faraday_middleware", "~> 0.9.1"
   spec.add_dependency "pg", "~> 0.18.1"
-  spec.add_dependency "sequel", "~> 4.21.0"
+  spec.add_dependency "sequel", "~> 5.5.0"
   spec.add_dependency "activesupport", ">= 4.0.0"
   spec.add_dependency "contracts", "~> 0.9"
   spec.add_dependency "typhoeus", "~> 0.8.0"


### PR DESCRIPTION
- Upgrade temporary network to protocol version 9 before running recipes
- Upgrade sequel to latest version to remove warnings
- Add error message when running against an existing directory