### PR TITLE
use protocol version 9 until version 10 is released

### DIFF
--- a/lib/stellar_core_commander/process.rb
+++ b/lib/stellar_core_commander/process.rb
@@ -302,7 +302,7 @@ module StellarCoreCommander
 
     Contract None => Any
     def set_upgrades
-      response = server.get('/upgrades?mode=set&upgradetime=1970-01-01T00:00:00Z&maxtxsize=10000&protocolversion=10')
+      response = server.get('/upgrades?mode=set&upgradetime=1970-01-01T00:00:00Z&maxtxsize=10000&protocolversion=9')
       response = response.body.downcase
       if response.include? "exception"
         $stderr.puts "Did not submit upgrades: #{response}"


### PR DESCRIPTION
Version 10 is not yet released, so we can only upgrade to version 9 for now (when testing against testnet/prod).

Do not merge until https://github.com/stellar/stellar-core/pull/1663 is merged as currently stellar-core can only process an upgrade to the latest version of the protocol that it supports.