### PR TITLE
Update loadgen calls

### DIFF
--- a/lib/stellar_core_commander/process.rb
+++ b/lib/stellar_core_commander/process.rb
@@ -391,6 +391,13 @@ module StellarCoreCommander
       {}
     end
 
+    Contract None => Any
+    def clear_metrics
+      server.get("/clearmetrics")
+    rescue
+      nil
+    end
+
     Contract String => Num
     def metrics_count(k)
       m = metrics
@@ -473,9 +480,9 @@ module StellarCoreCommander
       true
     end
 
-    Contract Num, Num, Or[Symbol, Num] => Any
-    def start_load_generation(accounts, txs, txrate)
-      server.get("/generateload?accounts=#{accounts}&txs=#{txs}&txrate=#{txrate}")
+    Contract Symbol, Num, Num, Num, Or[Symbol, Num], Num => Any
+    def start_load_generation(mode, accounts, offset, txs, txrate, batchsize)
+      server.get("/generateload?mode=#{mode}&accounts=#{accounts}&offset=#{offset}&txs=#{txs}&txrate=#{txrate}&batchsize=#{batchsize}")
     end
 
     Contract None => Num

--- a/lib/stellar_core_commander/transactor.rb
+++ b/lib/stellar_core_commander/transactor.rb
@@ -225,10 +225,10 @@ module StellarCoreCommander
       end
     end
 
-    Contract Num, Num, Or[Symbol, Num] => Any
-    def start_load_generation(accounts=10000000, txs=10000000, txrate=500)
+    Contract Symbol, Num, Num, Num, Or[Symbol, Num], Num => Any
+    def start_load_generation(mode=:create, accounts=10000000, offset=0, txs=10000000, txrate=500, batchsize=100)
       $stderr.puts "starting load generation: #{accounts} accounts, #{txs} txs, #{txrate} tx/s"
-      @process.start_load_generation accounts, txs, txrate
+      @process.start_load_generation mode, accounts, offset, txs, txrate, batchsize
     end
 
     Contract None => Bool
@@ -236,16 +236,18 @@ module StellarCoreCommander
       @process.load_generation_complete
     end
 
-    Contract Num, Num, Or[Symbol, Num] => Any
-    def generate_load_and_await_completion(accounts, txs, txrate)
+    Contract Symbol, Num, Num, Num, Or[Symbol, Num], Num => Any
+    def generate_load_and_await_completion(mode, accounts, offset, txs, txrate, batchsize)
       runs = @process.load_generation_runs
-      start_load_generation accounts, txs, txrate
-      retry_until_true retries: accounts + txs do
+      start_load_generation mode, accounts, offset, txs, txrate, batchsize
+      num_retries = if mode == :create then accounts else txs end
+
+      retry_until_true retries: num_retries do
         txs = @process.transactions_applied
         r = @process.load_generation_runs
         tps = @process.transactions_per_second
         ops = @process.operations_per_second
-        $stderr.puts "loadgen runs: #{r}, ledger: #{ledger_num}, txs: #{txs}, actual tx/s: #{tps} op/s: #{ops}"
+        $stderr.puts "loadgen runs: #{r}, ledger: #{ledger_num}, accounts: #{accounts}, txs: #{txs}, actual tx/s: #{tps} op/s: #{ops}"
         r != runs
       end
     end
@@ -253,6 +255,11 @@ module StellarCoreCommander
     Contract None => Hash
     def metrics
       @process.metrics
+    end
+
+    Contract None => Any
+    def clear_metrics
+      @process.clear_metrics
     end
 
     Contract Symbol, ArrayOf[Symbol], Hash => Process


### PR DESCRIPTION
`generateload` endpoint has been updated on stellar-core side (currently in master, but not in testnet/pubnet). This PR updates scc to reflect those changes.