### PR TITLE
increase timeout for applying buckets

### DIFF
--- a/lib/stellar_core_commander/process.rb
+++ b/lib/stellar_core_commander/process.rb
@@ -660,8 +660,8 @@ module StellarCoreCommander
       elsif has_special_peers?
         # testnet and pubnet have relatively more complex history
         # we give ourself:
-        # 3 checkpoints + 5 minutes to apply buckets  + 0.1 second per ledger replayed
-        (5.0 * 64 * 3) + ( 5 * 60 ) + (@catchup_recent ? (0.1 * @catchup_recent): 0)
+        # 3 checkpoints + 20 minutes to apply buckets  + 0.1 second per ledger replayed
+        (5.0 * 64 * 3) + ( 20 * 60 ) + (@catchup_recent ? (0.1 * @catchup_recent): 0)
       else
         # Checkpoints are made every 64 ledgers = 320s on a normal network,
         # or every 8 ledgers = 8s on an accelerated-time network; we give you


### PR DESCRIPTION
it takes about 20 minutes to apply buckets from the public network on slow & virtualized hardware right now (faster on real machines).
Bumping the timeout for now until we find a better solution