### PR TITLE
Add sqlite support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@ Or install it yourself as:
 
 At present `scc` makes a few assumptions about the environment it runs in that you should be aware.  In the event that your own environment differs from the below assumptions, `scc` will definitely break.
 
-1.  Postgresql is installed locally and `pg_dump`, `createdb` and `dropdb` are available on your PATH
-2.  The `which` command is available on your system.
-3.  Postgresql is running and the current user has passwordless access to it.  Running `psql postgres -c "\l"` should confirm you're setup correctly.
-4.  Your current user has access to create and drop postgres databases.  Test using: `createdb foobar && dropdb foobar`
-5.  A working `stellar-core` binary is available on your path (or specified using the `--stellar-core-bin` flag)
-6.  Your system has libsodium installed
+1.  The `which` command is available on your system.
+2.  A working `stellar-core` binary is available on your path (or specified using the `--stellar-core-bin` flag)
+3.  Your system has libsodium installed
 
+If you choose to use Postgres:
+1. Postgresql is installed locally and `pg_dump`, `createdb` and `dropdb` are available on your PATH
+2. Postgresql is running and the current user has passwordless access to it.  Running `psql postgres -c "\l"` should confirm you're setup correctly
+3. Your current user has access to create and drop postgres databases.  Test using: `createdb foobar && dropdb foobar`
 
 ## Usage As Command Line Tool
 
@@ -65,6 +66,15 @@ The next statement is more complex: `payment :master, :scott, [:native, 1000_000
 
 `:master` (sometimes also called the "root" account) is a special account that is created when a new ledger is initialized.  We often use it in our recipes to fund other accounts, since in a ledgers initial state the :master account has all 100 billion lumen.
 
+You can also spin up multiple stellar-core instances using `process`, where you need to specify node name, quorum sets, and possibly options. If you wish to use SQLite, you need to specify the option `database_url`. For example, the following code spins up a stellar-core instance, and generates some artificial load:
+```ruby
+process :node, [:node], host: ENV['DOCKER1'],  database_url: "sqlite3://stellar.db"
+on :node do
+    generate_load_and_await_completion :create, accounts, 0, 2, 100
+end
+```
+
+Note that current SQLite support is very limited
 ### Recipe Reference
 
 All recipe execute within the context of a `StellarCoreCommander::Transactor`.  [See the code for all available methods](lib/stellar_core_commander/transactor.rb).

--- a/lib/stellar_core_commander/commander.rb
+++ b/lib/stellar_core_commander/commander.rb
@@ -46,6 +46,11 @@ module StellarCoreCommander
         manual_close: transactor.manual_close
       }).merge(options)
 
+      if process_options.key? :database_url
+        db = process_options[:database_url]
+        $stderr.puts "manually configured DB: #{db}"
+      end
+
       process_class = case @process_type
                         when 'local'
                           LocalProcess

--- a/lib/stellar_core_commander/local_process.rb
+++ b/lib/stellar_core_commander/local_process.rb
@@ -11,7 +11,7 @@ module StellarCoreCommander
 
       super
       @stellar_core_bin = params[:stellar_core_bin]
-      @database_url     = params[:database].try(:strip)
+      @database_url     = params[:database_url].try(:strip)
       @cmd              = Cmd.new(working_dir)
 
       setup_working_dir
@@ -61,7 +61,7 @@ module StellarCoreCommander
     Contract None => Any
     def setup!
       write_config
-      create_database unless @keep_database
+      create_database unless @keep_database or is_sqlite
       initialize_database
       initialize_history
     end
@@ -98,12 +98,12 @@ module StellarCoreCommander
     Contract None => Any
     def cleanup
       database.disconnect
-      dump_database
+      dump_database unless is_sqlite
       dump_scp_state
       dump_info
       dump_metrics
       shutdown
-      drop_database unless @keep_database
+      drop_database unless @keep_database or is_sqlite
     end
 
     Contract None => Any


### PR DESCRIPTION
Allow running stellar-core with SQLite store. This option is used for benchmark tests. Note that integrity check in scc is not supported with SQLite, mostly because I had difficulties accessing SQLite db on test nodes from Jenkins server (it doesn't work like PG where we can connect to the server); however, this should be okay because the load generator we are using SQLite for ensures integrity on stellar-core side. 