### PR TITLE
Auto upgrade core version and allow version setup manually

### DIFF
--- a/lib/stellar_core_commander/transactor.rb
+++ b/lib/stellar_core_commander/transactor.rb
@@ -339,6 +339,11 @@ module StellarCoreCommander
       @commander.check_no_process_error_metrics
     end
 
+    Contract Or[Num, String] => Any
+    def set_upgrades(protocolversion)
+      @process.set_upgrades protocolversion
+    end
+
     Contract ArrayOf[Or[Symbol, Process]] => Bool
     def check_equal_ledger_objects(processes)
       raise "no process!" unless @process


### PR DESCRIPTION
Resolves #112 

Tested locally with recipes setting upgrades when spinning up a node as well as setting upgrades mid-recipe. Supports string/int versions (9, "9") and "latest".