### PR TITLE
use new metrics for invariant failures and internal errors

### DIFF
--- a/lib/stellar_core_commander/transactor.rb
+++ b/lib/stellar_core_commander/transactor.rb
@@ -383,6 +383,11 @@ module StellarCoreCommander
       @commander.check_no_process_error_metrics
     end
 
+    Contract Bool => Bool
+    def check_no_error_metrics_param(internal_error)
+      @commander.check_no_error_metrics_param(internal_error)
+    end
+
     Contract Or[Num, String] => Any
     def set_upgrades(protocolversion)
       @process.set_upgrades protocolversion


### PR DESCRIPTION
after we merge https://github.com/stellar/stellar-core/pull/1894 we can take advantage of the new checks in acceptance runs