### PR TITLE
Small fixes

### DIFF
--- a/bin/scc
+++ b/bin/scc
@@ -92,10 +92,7 @@ def run
   #run the recipe
   $stdout.puts "running recipe"
   transactor.run_recipe recipe
-  $stdout.puts "recipe finished, closing ledger"
-  transactor.close_ledger
-  $stdout.puts "ledger closed"
-
+  $stdout.puts "recipe finished"
 
   if $opts[:"dump-root-db"]
     file = commander.get_root_process(transactor).dump_database

--- a/lib/stellar_core_commander/local_process.rb
+++ b/lib/stellar_core_commander/local_process.rb
@@ -97,7 +97,7 @@ module StellarCoreCommander
 
     Contract None => Any
     def cleanup
-      database.disconnect
+      database.disconnect unless is_sqlite
       dump_database unless is_sqlite
       dump_scp_state
       dump_info


### PR DESCRIPTION
Looks like there aren't enough of `unless` in scc :) 

Missed it in the SQLite support PR, so adding it for local processes. Also, removed ledger close in `scc` - not sure what it tries to accomplish, as it should be done on the recipe level (if needed)