### PR TITLE
Fix quorum-number extraction from /info endpoint

### DIFF
--- a/lib/stellar_core_commander/process.rb
+++ b/lib/stellar_core_commander/process.rb
@@ -417,7 +417,14 @@ module StellarCoreCommander
     Contract None => Num
     def scp_quorum_num
       q = scp_quorum_info
-      q.keys[0].to_i
+      # In 11.2 we changed the representation of
+      # the /info endpoint's "quorum" field; it now
+      # contains quorum.qset.ledger
+      if q.has_key? "qset"
+        q["qset"]["ledger"].to_i
+      else
+        q.keys[0].to_i
+      end
     rescue
       2
     end


### PR DESCRIPTION
Just compensates for the change in the endpoint that happened in https://github.com/stellar/stellar-core/commit/7df492c858c811f7bf53a29ba24247fea6602451