### PR TITLE
Support stellar-core protocol 12.

### DIFF
--- a/examples/path_payment_strict_send.rb
+++ b/examples/path_payment_strict_send.rb
@@ -1,0 +1,33 @@
+account :usd_gateway
+account :eur_gateway
+account :scott
+account :bartek
+account :andrew
+
+create_account :usd_gateway, :master
+create_account :eur_gateway, :master
+create_account :scott, :master
+create_account :bartek, :master
+create_account :andrew, :master
+
+close_ledger
+
+trust :scott,  :usd_gateway, "USD"
+trust :bartek, :eur_gateway, "EUR"
+trust :andrew, :usd_gateway, "USD"
+trust :andrew, :eur_gateway, "EUR"
+
+close_ledger
+
+payment :usd_gateway, :scott,  ["USD", :usd_gateway, 1000]
+payment :usd_gateway, :andrew, ["USD", :usd_gateway, 200]
+payment :eur_gateway, :andrew, ["EUR", :eur_gateway, 200]
+payment :eur_gateway, :bartek, ["EUR", :eur_gateway, 1000]
+
+close_ledger
+
+offer :andrew, {buy:["USD", :usd_gateway], with:["EUR", :eur_gateway]}, 200, 1.0
+
+close_ledger
+
+path_payment_strict_send :scott, :bartek, ["EUR", :eur_gateway, 10], with: ["USD", :usd_gateway, 10], path: []

--- a/examples/path_payment_strict_send.rb
+++ b/examples/path_payment_strict_send.rb
@@ -31,3 +31,5 @@ offer :andrew, {buy:["USD", :usd_gateway], with:["EUR", :eur_gateway]}, 200, 1.0
 close_ledger
 
 path_payment_strict_send :scott, :bartek, ["EUR", :eur_gateway, 10], with: ["USD", :usd_gateway, 10], path: []
+
+close_ledger

--- a/lib/stellar_core_commander/horizon_commander.rb
+++ b/lib/stellar_core_commander/horizon_commander.rb
@@ -99,6 +99,7 @@ module StellarCoreCommander
       :add_signer,
       :remove_signer,
       :add_onetime_signer,
+      :path_payment_strict_send,
       :set_master_signer_weight,
       :set_thresholds,
       :set_inflation_dest,

--- a/lib/stellar_core_commander/transaction_builder.rb
+++ b/lib/stellar_core_commander/transaction_builder.rb
@@ -80,10 +80,30 @@ module StellarCoreCommander
       tx =  if options[:with]
               attrs[:with] = normalize_amount(options[:with])
               attrs[:path] = options[:path].map{|p| make_asset p}
-              Stellar::Transaction.path_payment(attrs)
+              Stellar::Transaction.path_payment_strict_receive(attrs)
             else
               Stellar::Transaction.payment(attrs)
             end
+
+      tx.to_envelope(from)
+    end
+
+    Contract Symbol, Symbol, Amount, PaymentOptions => Any
+    def path_payment_strict_send(from, to, amount, options={})
+      from = get_account from
+      to   = get_account to
+
+      attrs = {
+        account:     from,
+        destination: to,
+        memo:        options[:memo],
+        sequence:    next_sequence(from),
+        amount:      normalize_amount(amount),
+        with:        normalize_amount(options[:with]),
+        path:        options[:path].map{|p| make_asset p}
+      }
+
+      tx =  Stellar::Transaction.path_payment_strict_send(attrs)
 
       tx.to_envelope(from)
     end

--- a/lib/stellar_core_commander/transaction_builder.rb
+++ b/lib/stellar_core_commander/transaction_builder.rb
@@ -89,6 +89,26 @@ module StellarCoreCommander
     end
 
     Contract Symbol, Symbol, Amount, PaymentOptions => Any
+    def path_payment_strict_receive(from, to, amount, options={})
+      from = get_account from
+      to   = get_account to
+
+      attrs = {
+        account:     from,
+        destination: to,
+        memo:        options[:memo],
+        sequence:    next_sequence(from),
+        amount:      normalize_amount(amount),
+        with:        normalize_amount(options[:with]),
+        path:        options[:path].map{|p| make_asset p}
+      }
+
+      tx =  Stellar::Transaction.path_payment_strict_receive(attrs)
+
+      tx.to_envelope(from)
+    end
+
+    Contract Symbol, Symbol, Amount, PaymentOptions => Any
     def path_payment_strict_send(from, to, amount, options={})
       from = get_account from
       to   = get_account to

--- a/lib/stellar_core_commander/transactor.rb
+++ b/lib/stellar_core_commander/transactor.rb
@@ -111,6 +111,22 @@ module StellarCoreCommander
 
     #
     # @see StellarCoreCommander::TransactionBuilder#path_payment_strict_send
+    def path_payment_strict_receive(*args, &block)
+      require_process_running
+      envelope = @transaction_builder.path_payment_strict_receive(*args)
+
+      if block.present?
+        block.call envelope
+      end
+
+      submit_transaction envelope do |result|
+        payment_result = result.result.results!.first.tr!.value
+        raise FailedTransaction unless payment_result.code.value >= 0
+      end
+    end
+
+    #
+    # @see StellarCoreCommander::TransactionBuilder#path_payment_strict_send
     def path_payment_strict_send(*args, &block)
       require_process_running
       envelope = @transaction_builder.path_payment_strict_send(*args)

--- a/lib/stellar_core_commander/transactor.rb
+++ b/lib/stellar_core_commander/transactor.rb
@@ -109,6 +109,22 @@ module StellarCoreCommander
       end
     end
 
+    #
+    # @see StellarCoreCommander::TransactionBuilder#path_payment_strict_send
+    def path_payment_strict_send(*args, &block)
+      require_process_running
+      envelope = @transaction_builder.path_payment_strict_send(*args)
+
+      if block.present?
+        block.call envelope
+      end
+
+      submit_transaction envelope do |result|
+        payment_result = result.result.results!.first.tr!.value
+        raise FailedTransaction unless payment_result.code.value >= 0
+      end
+    end
+
     # @see StellarCoreCommander::TransactionBuilder#create_account
     recipe_step :create_account
 


### PR DESCRIPTION
Add support for `path_payment_strict_send` and `path_payment_strict_receive`

### Testing 

You cant test this PR installing directly from this branch and then running scc.

#### Install 

```
git clone git@github.com:stellar/stellar_core_commander.git
git checkout core12-support
gem build stellar_core_commander.gemspec
gem install stellar_core_commander-0.0.13.gem
```

#### Run scc

Copy the following code into an file called `path_payment.rb`

```
account :usd_gateway
account :eur_gateway
account :scott
account :bartek
account :andrew

create_account :usd_gateway, :master
create_account :eur_gateway, :master
create_account :scott, :master
create_account :bartek, :master
create_account :andrew, :master

close_ledger

trust :scott,  :usd_gateway, "USD"
trust :bartek, :eur_gateway, "EUR"
trust :andrew, :usd_gateway, "USD"
trust :andrew, :eur_gateway, "EUR"

close_ledger

payment :usd_gateway, :scott,  ["USD", :usd_gateway, 1000]
payment :usd_gateway, :andrew, ["USD", :usd_gateway, 200]
payment :eur_gateway, :andrew, ["EUR", :eur_gateway, 200]
payment :eur_gateway, :bartek, ["EUR", :eur_gateway, 1000]

close_ledger

offer :andrew, {buy:["USD", :usd_gateway], with:["EUR", :eur_gateway]}, 200, 1.0

close_ledger

path_payment_strict_send :scott, :bartek, ["EUR", :eur_gateway, 10], with: ["USD", :usd_gateway, 10], path: []
path_payment_strict_receive :scott, :bartek, ["EUR", :eur_gateway, 10], with: ["USD", :usd_gateway, 10], path: []

close_ledger
```

And then run `scc -r path_payment.rb --allow-failed-transactions --dump-root-db > path.sql`



