### PR TITLE
Avoid printing debug messages to stdout

### DIFF
--- a/bin/scc
+++ b/bin/scc
@@ -90,9 +90,9 @@ def run
   transactor = StellarCoreCommander::Transactor.new(commander)
 
   #run the recipe
-  $stdout.puts "running recipe"
+  $stderr.puts "running recipe"
   transactor.run_recipe recipe
-  $stdout.puts "recipe finished"
+  $stderr.puts "recipe finished"
 
   if $opts[:"dump-root-db"]
     file = commander.get_root_process(transactor).dump_database


### PR DESCRIPTION
According to the readme:

> scc takes a recipe file, spins up a test network, plays the defined transactions against it, then dumps the ledger database to stdout

However, when debug messages are also present in stdout the user of the command needs to separate the debug messages from the actual sql statements. This also imposes a burden on scripts which use `scc` to generate sql dumps.